### PR TITLE
Feature Test Mode

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,10 +11,12 @@ module "lambda" {
   source_path = "${path.module}/src/"
 
   environment_variables = {
-    HOOK_URL          = var.slack_hook_url
-    RULES             = var.rules
-    EVENTS_TO_TRACK   = var.events_to_track
-    USE_DEFAULT_RULES = var.use_default_rules
+    HOOK_URL           = var.slack_hook_url
+    TEST_MODE          = var.enable_test_mode ? "Enable" : ""
+    HOOK_URL_TEST_MODE = var.slack_hook_url_test_mode
+    RULES              = var.rules
+    EVENTS_TO_TRACK    = var.events_to_track
+    USE_DEFAULT_RULES  = var.use_default_rules
   }
 
   cloudwatch_logs_retention_in_days = 30

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "1.48.0"
+  version = "2.7.0"
 
   function_name = var.function_name
   description   = "Send CloudTrail Events to Slack"
@@ -34,7 +34,7 @@ data "aws_cloudwatch_log_group" "cloudtrail" {
 resource "aws_lambda_permission" "permission" {
   statement_id  = "AllowExecutionFromCloudWatchLogs"
   action        = "lambda:InvokeFunction"
-  function_name = module.lambda.this_lambda_function_name
+  function_name = module.lambda.lambda_function_name
   source_arn    = data.aws_cloudwatch_log_group.cloudtrail.arn
   principal     = "logs.${data.aws_region.r.name}.amazonaws.com"
 }
@@ -43,5 +43,5 @@ resource "aws_cloudwatch_log_subscription_filter" "logfilter" {
   name            = var.function_name
   log_group_name  = data.aws_cloudwatch_log_group.cloudtrail.name
   filter_pattern  = ""
-  destination_arn = module.lambda.this_lambda_function_arn
+  destination_arn = module.lambda.lambda_function_arn
 }

--- a/src/main.py
+++ b/src/main.py
@@ -50,7 +50,10 @@ def read_env_variable_or_die(env_var_name):
 
 
 def lambda_handler(event, context):
-    hook_url = read_env_variable_or_die('HOOK_URL')
+    if os.environ.get('TEST_MODE', None):
+        hook_url = read_env_variable_or_die('HOOK_URL_TEST_MODE')
+    else
+        hook_url = read_env_variable_or_die('HOOK_URL')    
     user_rules = os.environ.get('RULES', None)
     use_default_rules = os.environ.get('USE_DEFAULT_RULES', None)
     events_to_track = os.environ.get('EVENTS_TO_TRACK', None)

--- a/vars.tf
+++ b/vars.tf
@@ -10,6 +10,18 @@ variable "slack_hook_url" {
   type        = string
 }
 
+variable "slack_hook_url_test_mode" {
+  description = "Slack incoming webhook URL for recieve envent in test mode"
+  type        = string
+  default     = ""
+}
+
+variable "enable_test_mode" {
+  description = "Enable Test mode and send events to `slack_hook_url_test_mode`"
+  type        = bool
+  default     = false
+}
+
 variable "cloudtrail_cloudwatch_log_group_name" {
   description = "Name of the CloudWatch log group that contains CloudTrail events"
   type        = string


### PR DESCRIPTION
Additional functional
Temporarily redirects all CloudTrail Events to the test Slack channel
It can be useful at the time of the initial installation, or in case of a large number of CloudTrail errors