### PR TITLE
Feat: cloudtrail logs kms key

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Apache 2 Licensed. See LICENSE for full details.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.62.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
 
 ## Modules
 
@@ -265,12 +265,14 @@ Apache 2 Licensed. See LICENSE for full details.
 | [aws_lambda_permission.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_iam_policy_document.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_kms_key.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_s3_bucket.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cloudtrail_logs_kms_key_id"></a> [cloudtrail\_logs\_kms\_key\_id](#input\_cloudtrail\_logs\_kms\_key\_id) | Alias, key id or key arn of the KMS Key that used for CloudTrail events | `string` | `""` | no |
 | <a name="input_cloudtrail_logs_s3_bucket_name"></a> [cloudtrail\_logs\_s3\_bucket\_name](#input\_cloudtrail\_logs\_s3\_bucket\_name) | Name of the CloudWatch log s3 bucket that contains CloudTrail events | `string` | n/a | yes |
 | <a name="input_configuration"></a> [configuration](#input\_configuration) | Allows to configure slack web hook url per account(s) so you can separate events from different accounts to different channels. Useful in context of AWS organization | <pre>list(object({<br>    accounts       = list(string)<br>    slack_hook_url = string<br>  }))</pre> | `null` | no |
 | <a name="input_dead_letter_target_arn"></a> [dead\_letter\_target\_arn](#input\_dead\_letter\_target\_arn) | The ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,27 @@ data "aws_iam_policy_document" "s3" {
       "${data.aws_s3_bucket.cloudtrail.arn}/*",
     ]
   }
+  dynamic "statement" {
+    for_each = var.cloudtrail_logs_kms_key_id != "" ? { create = true } : {}
+    content {
+      sid = "AllowLambdaToUseKMSKey"
+
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+      ]
+
+      resources = [
+        data.aws_kms_key.cloudtrail[0].arn,
+      ]
+    }
+  }
+
+}
+
+data "aws_kms_key" "cloudtrail" {
+  count  = var.cloudtrail_logs_kms_key_id != "" ? 1 : 0
+  key_id = var.cloudtrail_logs_kms_key_id
 }
 
 data "aws_s3_bucket" "cloudtrail" {

--- a/vars.tf
+++ b/vars.tf
@@ -24,6 +24,12 @@ variable "cloudtrail_logs_s3_bucket_name" {
   type        = string
 }
 
+variable "cloudtrail_logs_kms_key_id" {
+  description = "Alias, key id or key arn of the KMS Key that used for CloudTrail events"
+  type        = string
+  default     = ""
+}
+
 variable "events_to_track" {
   description = "Comma-separated list events to track and report"
   default     = ""


### PR DESCRIPTION
If AWS KMS CMK is used for CloudTrail, you need to add additional rights for the Lambda being launched