### PR TITLE
Attach source_account to lambda permissions.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,12 +72,15 @@ data "aws_s3_bucket" "cloudtrail" {
   bucket = var.cloudtrail_logs_s3_bucket_name
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_lambda_permission" "s3" {
-  statement_id  = "AllowExecutionFromS3Bucket"
-  action        = "lambda:InvokeFunction"
-  function_name = module.lambda.lambda_function_name
-  principal     = "s3.amazonaws.com"
-  source_arn    = data.aws_s3_bucket.cloudtrail.arn
+  statement_id   = "AllowExecutionFromS3Bucket"
+  action         = "lambda:InvokeFunction"
+  function_name  = module.lambda.lambda_function_name
+  principal      = "s3.amazonaws.com"
+  source_arn     = data.aws_s3_bucket.cloudtrail.arn
+  source_account = data.aws_caller_identity.current.account_id
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {


### PR DESCRIPTION
Recommended by AWS Foundational Security Best Pracices "Lambda-1-Remedation"
See https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#lambda-1-remediation and https://docs.aws.amazon.com/config/latest/developerguide/lambda-function-public-access-prohibited.html