### PR TITLE
Add Optional filter_prefix Variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ module "lambda" {
   dead_letter_target_arn    = var.dead_letter_target_arn
   attach_dead_letter_policy = var.dead_letter_target_arn != null ? true : false
 
+  memory_size = var.lambda_memory_size
   tags = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   lambda_function {
     lambda_function_arn = module.lambda.lambda_function_arn
     events              = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-    filter_prefix       = "AWSLogs/"
+    filter_prefix       = var.filter_prefix
     filter_suffix       = ".json.gz"
   }
 

--- a/vars.tf
+++ b/vars.tf
@@ -60,6 +60,12 @@ variable "dead_letter_target_arn" {
   default     = null
 }
 
+variable "lambda_memory_size" {
+  description = "Controls lambda memory setting."
+  type        = number
+  default     = 512
+}
+
 variable "lambda_timeout_seconds" {
   description = "Controls lambda timeout setting."
   type        = number

--- a/vars.tf
+++ b/vars.tf
@@ -78,3 +78,8 @@ variable "tags" {
   type        = map(string)
 }
 
+variable "filter_prefix" {
+  description = "Filter prefix on s3 bucket"
+  type        = string
+  default     = "AWSLogs/"
+}


### PR DESCRIPTION
Our s3 URI looks like this:

`s3://test/CloudTrail/AWSLogs/.../`

But in the [aws_s3_bucket_notification resource "bucket_notification"](https://github.com/fivexl/terraform-aws-cloudtrail-to-slack/blob/master/main.tf#L92), the filter_prefix is hardcoded to "AWSLogs/" which does not work for us. The PR just aims to make the filter_prefix an optional variable and still make "AWSLogs/" as the default value.