### PR TITLE
Custom rules separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -208,6 +208,22 @@ module "cloudtrail_to_slack" {
   rules                          = join(",", local.cloudtrail_rules)
 }
 ```
+### Using a custom separator for complex rules containing commas
+
+```hcl
+locals {
+  cloudtrail_rules = [
+      ...
+    ]
+  custom_separator = "%"
+}
+
+module "cloudtrail_to_slack" {
+      ...
+  rules           = join(local.custom_separator, local.cloudtrail_rules)
+  rules_separator = local.custom_separator
+}
+```
 
 ## Ignore rules.
 
@@ -354,6 +370,7 @@ tested with any other rules.
 | <a name="input_rules"></a> [rules](#input\_rules) | Comma-separated list of rules to track events if just event name is not enough | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to attach to resources | `map(string)` | `{}` | no |
 | <a name="input_use_default_rules"></a> [use\_default\_rules](#input\_use\_default\_rules) | Should default rules be used | `bool` | `true` | no |
+| <a name="input_rules_separator"></a> [rules\_separator](#input\rules\_separator) | Custom rules separator. Must be defined if there are commas in the rules | `string` | `","` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ module "lambda" {
   environment_variables = merge(
     {
       HOOK_URL        = var.default_slack_hook_url
+      RULES_SEPARATOR = var.rules_separator
       RULES           = var.rules
       IGNORE_RULES    = var.ignore_rules
       EVENTS_TO_TRACK = var.events_to_track

--- a/src/main.py
+++ b/src/main.py
@@ -98,8 +98,9 @@ def get_hook_url_for_account(event, configuration, default_hook_url):
 def lambda_handler(event, context):
 
     default_hook_url = read_env_variable_or_die('HOOK_URL')
-    user_rules = parse_rules_from_string(os.environ.get('RULES', ''))
-    ignore_rules = parse_rules_from_string(os.environ.get('IGNORE_RULES', ''))
+    rules_separator = os.environ.get('RULES_SEPARATOR', ',')
+    user_rules = parse_rules_from_string(os.environ.get('RULES', ''), rules_separator)
+    ignore_rules = parse_rules_from_string(os.environ.get('IGNORE_RULES', ''), rules_separator)
     use_default_rules = os.environ.get('USE_DEFAULT_RULES', None)
     events_to_track = os.environ.get('EVENTS_TO_TRACK', None)
     configuration = os.environ.get('CONFIGURATION', None)
@@ -187,8 +188,8 @@ def flatten_json(y):
 
 
 # Parse rules from string
-def parse_rules_from_string(rules_as_string):
-    rules_as_list = rules_as_string.split(',')
+def parse_rules_from_string(rules_as_string, rules_separator):
+    rules_as_list = rules_as_string.split(rules_separator)
     # make sure there are no empty strings in the list
     return [x for x in rules_as_list if x]
 

--- a/vars.tf
+++ b/vars.tf
@@ -78,3 +78,9 @@ variable "tags" {
   type        = map(string)
 }
 
+variable "rules_separator" {
+  description = "Custom rules separator. Can be used if there are commas in the rules"
+  default     = ","
+  type        = string
+}
+


### PR DESCRIPTION
In order to be able to use more complex rules. 
Some rules may contain commas but `rules_as_list = rules_as_string.split(',')` split it and break. 