### PR TITLE
Optional short messages to a slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ tested with any other rules.
 | <a name="input_use_default_rules"></a> [use\_default\_rules](#input\_use\_default\_rules) | Should default rules be used | `bool` | `true` | no |
 | <a name="input_rules_separator"></a> [rules\_separator](#input\rules\_separator) | Custom rules separator. Must be defined if there are commas in the rules | `string` | `","` | no |
 | <a name="input_short_messages"></a> [short\_messages](#input\short\_messages) | Set to "True" if you are willing to get short messages containing links to events in AWS Console | `string` | `"False"` | no |
+| <a name="input_cloudtrail_home_region"></a> [cloudtrail\_home\_region](#input\cloudtrail\_home\_region) |Region in which the trail was created. Value must to be defined  if short_messages is "True"| `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ tested with any other rules.
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to attach to resources | `map(string)` | `{}` | no |
 | <a name="input_use_default_rules"></a> [use\_default\_rules](#input\_use\_default\_rules) | Should default rules be used | `bool` | `true` | no |
 | <a name="input_rules_separator"></a> [rules\_separator](#input\rules\_separator) | Custom rules separator. Must be defined if there are commas in the rules | `string` | `","` | no |
+| <a name="input_short_messages"></a> [short\_messages](#input\short\_messages) | Set to "True" if you are willing to get short messages containing links to events in AWS Console | `string` | `"False"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -13,13 +13,14 @@ module "lambda" {
 
   environment_variables = merge(
     {
-      HOOK_URL        = var.default_slack_hook_url
-      RULES_SEPARATOR = var.rules_separator
-      RULES           = var.rules
-      IGNORE_RULES    = var.ignore_rules
-      EVENTS_TO_TRACK = var.events_to_track
-      CONFIGURATION   = var.configuration != null ? jsonencode(var.configuration) : ""
-      SHORT_MESSAGES  = var.short_messages
+      HOOK_URL          = var.default_slack_hook_url
+      RULES_SEPARATOR   = var.rules_separator
+      RULES             = var.rules
+      IGNORE_RULES      = var.ignore_rules
+      EVENTS_TO_TRACK   = var.events_to_track
+      CONFIGURATION     = var.configuration != null ? jsonencode(var.configuration) : ""
+      SHORT_MESSAGES    = var.short_messages
+      CLOUDTRAIL_REGION = var.cloudtrail_home_region
     },
     var.use_default_rules ? { USE_DEFAULT_RULES = "True" } : {}
   )

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ module "lambda" {
       IGNORE_RULES    = var.ignore_rules
       EVENTS_TO_TRACK = var.events_to_track
       CONFIGURATION   = var.configuration != null ? jsonencode(var.configuration) : ""
+      SHORT_MESSAGES  = var.short_messages
     },
     var.use_default_rules ? { USE_DEFAULT_RULES = "True" } : {}
   )

--- a/vars.tf
+++ b/vars.tf
@@ -84,3 +84,8 @@ variable "rules_separator" {
   type        = string
 }
 
+variable "short_messages" {
+  description = "Set to 'True' if you are willing to get short messages containing links to events in AWS Console"
+  default     = "False"
+  type        = string
+}

--- a/vars.tf
+++ b/vars.tf
@@ -89,3 +89,9 @@ variable "short_messages" {
   default     = "False"
   type        = string
 }
+
+variable "cloudtrail_home_region" {
+  description = "Region in which the trail was created. Value must to be defined if short_messages is 'True'"
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
Some events may contain huge requestParameters or responseElements sections, RunInstances events, for example. 
This PR adds a short_messages option. This will make lambda send links to the event in AWS Console instead of messages containing JSON objects. 