### PR TITLE
Get real partition name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,8 @@ module "lambda" {
   tags = var.tags
 }
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "s3" {
   statement {
     sid = "AllowLambdaToGetObjects"
@@ -87,7 +89,7 @@ data "aws_iam_policy_document" "s3" {
       "dynamodb:GetItem",
     ]
     resources = [
-      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb_table_name}"
+      "arn:${data.aws_partition.current.partition}:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb_table_name}"
     ]
   }
   dynamic "statement" {


### PR DESCRIPTION
I tried to use your module in AWS China, but partition name is different there ;-) Right now it will work in China and GOV region without any issues.