### PR TITLE
python 3.10.x everywhere

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -11,7 +11,7 @@ jobs:
   python-job:
     uses: fivexl/github-reusable-workflows/.github/workflows/python-job.yml@main
     with:
-      python-version: "3.10.10"
+      python-version: "3.10"
       aws-default-region: "eu-central-1"
       working-directory: "src"
 

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ module "lambda" {
   ]
 
   recreate_missing_package = var.lambda_recreate_missing_package
-  build_in_docker = var.lambda_build_in_docker
+  build_in_docker          = var.lambda_build_in_docker
 
   environment_variables = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ module "lambda" {
   ]
 
   recreate_missing_package = var.lambda_recreate_missing_package
+  build_in_docker = var.lambda_build_in_docker
 
   environment_variables = merge(
     {

--- a/src/deploy_requirements.txt
+++ b/src/deploy_requirements.txt
@@ -1,3 +1,3 @@
-slack-sdk==3.21.3 ; python_full_version == "3.10.10" \
+slack-sdk==3.21.3 ; python_full_version ~= "3.10" \
     --hash=sha256:20829bdc1a423ec93dac903470975ebf3bc76fd3fd91a4dadc0eeffc940ecb0c \
     --hash=sha256:de3c07b92479940b61cd68c566f49fbc9974c8f38f661d26244078f3903bb9cc

--- a/src/poetry.lock
+++ b/src/poetry.lock
@@ -353,5 +353,5 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "3.10.10"
+python-versions = "^3.10"
 content-hash = "07857fc18d692c1db8a53b15721d198062fa89ae0e268aaf533a2e3886ca0818"

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -6,13 +6,13 @@ authors = ["FivexL"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "3.10.10"
+python = "^3.10"
 slack-sdk = "^3.21.3"
 
 # Full list of dependencies, for development.
 # Can be installed with `poetry install --with dev`.
 [tool.poetry.group.dev.dependencies]
-python = "^3.10.10"
+python = "^3.10"
 pytest = "^7.2.2"
 black = "^24.3.0"
 boto3 = "^1.26.97"

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-black==24.3.0 ; python_full_version == "3.10.10" \
+black==24.3.0 ; python_full_version ~= "3.10" \
     --hash=sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f \
     --hash=sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93 \
     --hash=sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11 \
@@ -21,49 +21,49 @@ black==24.3.0 ; python_full_version == "3.10.10" \
     --hash=sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7 \
     --hash=sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd \
     --hash=sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7
-boto3==1.28.4 ; python_full_version == "3.10.10" \
+boto3==1.28.4 ; python_full_version ~= "3.10" \
     --hash=sha256:1f4b9c23dfcad910b6f8e74aac9fe507c1e75fcdd832e25ed2ff1e6d7a99cddf \
     --hash=sha256:92c0631ab91b4c5aa0e18a90b4d12df361723c6df1ef7e346db71f2ad0803ab3
-botocore==1.31.4 ; python_full_version == "3.10.10" \
+botocore==1.31.4 ; python_full_version ~= "3.10" \
     --hash=sha256:1c14ac4521af707a7a407cee0e22695ce3e95c0f1a0c974e21cb25a3ce78a538 \
     --hash=sha256:f9738a23b03c55c2958ebdee65273afeda80deaeefebe595887fc3251e48293a
-click==8.1.5 ; python_full_version == "3.10.10" \
+click==8.1.5 ; python_full_version ~= "3.10" \
     --hash=sha256:4be4b1af8d665c6d942909916d31a213a106800c47d0eeba73d34da3cbc11367 \
     --hash=sha256:e576aa487d679441d7d30abb87e1b43d24fc53bffb8758443b1a9e1cee504548
-colorama==0.4.6 ; python_full_version == "3.10.10" and (sys_platform == "win32" or platform_system == "Windows") \
+colorama==0.4.6 ; python_full_version ~= "3.10" and (sys_platform == "win32" or platform_system == "Windows") \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-exceptiongroup==1.1.2 ; python_full_version == "3.10.10" \
+exceptiongroup==1.1.2 ; python_full_version ~= "3.10" \
     --hash=sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5 \
     --hash=sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f
-iniconfig==2.0.0 ; python_full_version == "3.10.10" \
+iniconfig==2.0.0 ; python_full_version ~= "3.10" \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
-jmespath==1.0.1 ; python_full_version == "3.10.10" \
+jmespath==1.0.1 ; python_full_version ~= "3.10" \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
     --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
-mypy-extensions==1.0.0 ; python_full_version == "3.10.10" \
+mypy-extensions==1.0.0 ; python_full_version ~= "3.10" \
     --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
     --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
-packaging==23.1 ; python_full_version == "3.10.10" \
+packaging==23.1 ; python_full_version ~= "3.10" \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
-pathspec==0.11.1 ; python_full_version == "3.10.10" \
+pathspec==0.11.1 ; python_full_version ~= "3.10" \
     --hash=sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687 \
     --hash=sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293
-platformdirs==3.9.1 ; python_full_version == "3.10.10" \
+platformdirs==3.9.1 ; python_full_version ~= "3.10" \
     --hash=sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421 \
     --hash=sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f
-pluggy==1.2.0 ; python_full_version == "3.10.10" \
+pluggy==1.2.0 ; python_full_version ~= "3.10" \
     --hash=sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849 \
     --hash=sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3
-pytest==7.4.0 ; python_full_version == "3.10.10" \
+pytest==7.4.0 ; python_full_version ~= "3.10" \
     --hash=sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32 \
     --hash=sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a
-python-dateutil==2.8.2 ; python_full_version == "3.10.10" \
+python-dateutil==2.8.2 ; python_full_version ~= "3.10" \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
-ruff==0.0.267 ; python_full_version == "3.10.10" \
+ruff==0.0.267 ; python_full_version ~= "3.10" \
     --hash=sha256:0afca3633c8e2b6c0a48ad0061180b641b3b404d68d7e6736aab301c8024c424 \
     --hash=sha256:20c594eb56c19063ef5a57f89340e64c6550e169d6a29408a45130a8c3068adc \
     --hash=sha256:2107cec3699ca4d7bd41543dc1d475c97ae3a21ea9212238b5c2088fa8ee7722 \
@@ -81,21 +81,21 @@ ruff==0.0.267 ; python_full_version == "3.10.10" \
     --hash=sha256:d12ab329474c46b96d962e2bdb92e3ad2144981fe41b89c7770f370646c0101f \
     --hash=sha256:db33deef2a5e1cf528ca51cc59dd764122a48a19a6c776283b223d147041153f \
     --hash=sha256:f731d81cb939e757b0335b0090f18ca2e9ff8bcc8e6a1cf909245958949b6e11
-s3transfer==0.6.1 ; python_full_version == "3.10.10" \
+s3transfer==0.6.1 ; python_full_version ~= "3.10" \
     --hash=sha256:3c0da2d074bf35d6870ef157158641178a4204a6e689e82546083e31e0311346 \
     --hash=sha256:640bb492711f4c0c0905e1f62b6aaeb771881935ad27884852411f8e9cacbca9
-six==1.16.0 ; python_full_version == "3.10.10" \
+six==1.16.0 ; python_full_version ~= "3.10" \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-slack-sdk==3.21.3 ; python_full_version == "3.10.10" \
+slack-sdk==3.21.3 ; python_full_version ~= "3.10" \
     --hash=sha256:20829bdc1a423ec93dac903470975ebf3bc76fd3fd91a4dadc0eeffc940ecb0c \
     --hash=sha256:de3c07b92479940b61cd68c566f49fbc9974c8f38f661d26244078f3903bb9cc
-tomli==2.0.1 ; python_full_version == "3.10.10" \
+tomli==2.0.1 ; python_full_version ~= "3.10" \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
-typing-extensions==4.10.0 ; python_full_version == "3.10.10" \
+typing-extensions==4.10.0 ; python_full_version ~= "3.10" \
     --hash=sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475 \
     --hash=sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb
-urllib3==1.26.16 ; python_full_version == "3.10.10" \
+urllib3==1.26.16 ; python_full_version ~= "3.10" \
     --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \
     --hash=sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14

--- a/vars.tf
+++ b/vars.tf
@@ -157,6 +157,12 @@ variable "lambda_recreate_missing_package" {
   default     = true
 }
 
+variable "lambda_build_in_docker" {
+  type        = bool
+  default     = false
+  description = "Whether to build dependencies in Docker"
+}
+
 variable "tags" {
   description = "Tags to attach to resources"
   default     = {}


### PR DESCRIPTION
WIP 
Not tested, AI generated 

In case of python 3.10 version doesn't match with 3.10.10 we will deliver Lambda without Slack SDK 
It will be only warning inside the build log, that version doesn't match, and we are skipping Slack SDK 